### PR TITLE
Fixed decoding of maildata

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Mail can be retrieved from many different sources, including local mailboxes, re
 Beware that AtoMail is still in alpha stage, and that it probably contains
 bugs.
 
+I have updated this forked version to make it run again. No guarantees for anything though.
+
 
 ## Usage
 

--- a/atomail.py
+++ b/atomail.py
@@ -65,7 +65,6 @@ import poplib
 import mailbox
 import html
 import functools
-from flask import Flask, Response
 
 
 


### PR DESCRIPTION
Previously fetching from imap source lead to an error, as the fetched data was uft-6 encoded and not decoded to be useable as a string. Added additional function decode_bytes_to_str to fix this. I then only fixed the IMAPSource class, one may need to decode data from other sources if required.